### PR TITLE
Fix recursive directory creation

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -25,13 +25,13 @@ action :create do
     new_resource.bucket,
     new_resource.dir
   ).each do |filename|
-    if filename[-1] == '/'
-      directory "#{new_resource.name}#{filename}" do
+      dir_path = filename.split("/")[0..-2].join("/")
+      directory "#{new_resource.name}#{dir_path}" do
         owner     new_resource.owner
         group     new_resource.group
         mode      S3Lib::Dir.dir_mode new_resource.mode
+        recursive new_resource.recursive
       end
-    else
       s3_file "#{new_resource.name}#{filename}" do
         remote_path "#{new_resource.dir}#{filename}"
         bucket new_resource.bucket
@@ -43,6 +43,5 @@ action :create do
         s3_url "#{s3_dir_lib.s3_url}/#{new_resource.bucket}"
         action :create
       end
-    end
   end
 end


### PR DESCRIPTION
Whenever you have in S3 bucket folder, which doesn't has any files in it, but just another folder, fog won't return folder as separate resource.

Example:
/root/folderA/folderB/file
/root/folderA/folderC/file

s3_dir "/local/path" do
  bucket "bucketname"
  dir "root"
end

you won't get folderA as separate resource and as a result you will have chef error about creating file in missing directory

This ugly patch fixes this issue.