### PR TITLE
Handle nested directories properly

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -17,11 +17,11 @@ provisioner:
   name: chef_solo
 
 platforms:
-- name: ubuntu-12.04
+- name: ubuntu-14.04
   driver_config:
-    image_id: ami-b66ca0de
+    image_id: ami-b21a65d8
     tags:
-      Name: travis-ci-default-ubuntu-1204
+      Name: travis-ci-default-ubuntu-1404
       Env: public
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,3 +16,7 @@ suites:
   - name: default
     run_list:
       - recipe[s3_dir_test::default]
+    attributes:
+      s3_dir:
+        aws_access_key_id: <%= ENV['AWS_ACCESS_KEY'] %>
+        aws_secret_access_key: <%= ENV['AWS_SECRET_KEY'] %>

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,7 +10,7 @@ provisioner:
   name: chef_solo
 
 platforms:
-  - name: ubuntu-12.04
+  - name: ubuntu-14.04
 
 suites:
   - name: default

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,7 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.chef.io'
 
 metadata
 
-group :test do
+group :test, :integration do
   cookbook 's3_dir_test', path: 'test/cookbooks/s3_dir_test'
 end

--- a/libraries/s3_dir.rb
+++ b/libraries/s3_dir.rb
@@ -51,13 +51,11 @@ module S3Lib
 
       # 'files' is not a proper array and sometimes mishandles 'select.'
       # This converts it.
-      arr = []
-      bucket_obj.files.each { |f| arr << f }
-      listing = arr.select do |o|
-        o.key =~ /^#{Regexp.escape(dir)}/ &&
-          o.key !~ /^#{Regexp.escape(dir)}\/$/
+      listing = bucket_obj.files.all('prefix' => dir).map do |o|
+        o.key.sub(/^#{Regexp.escape(dir)}\//, '')
       end
-      listing.map { |o| o.key.sub(/^#{Regexp.escape(dir)}\//, '/') }
+
+      listing.reject(&:empty?)
     end
 
     private

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -21,28 +21,41 @@ action :create do
     new_resource.dir
   ) if new_resource.mock
 
-  s3_dir_lib.ls(
+  remote_dir_contents = s3_dir_lib.ls(
     new_resource.bucket,
     new_resource.dir
-  ).each do |filename|
-    if filename[-1] == '/'
-      directory "#{new_resource.name}#{filename}" do
-        owner     new_resource.owner
-        group     new_resource.group
-        mode      S3Lib::Dir.dir_mode new_resource.mode
-      end
-    else
-      s3_file "#{new_resource.name}#{filename}" do
-        remote_path "#{new_resource.dir}#{filename}"
-        bucket new_resource.bucket
-        aws_access_key_id new_resource.access_key_id
-        aws_secret_access_key new_resource.secret_access_key
-        owner new_resource.owner
-        group new_resource.group
-        mode new_resource.mode
-        s3_url "#{s3_dir_lib.s3_url}/#{new_resource.bucket}"
-        action :create
-      end
+  )
+
+  # Breaking out the directories here and processing them separately allows
+  # us to avoid creating duplicate resources and gets around the fact that
+  # s3_file cannot create paths recursively.
+  directories = remote_dir_contents.map do |f|
+    f[-1] == '/' ? f.sub(%r{/$}, '') : ::File.dirname(f)
+  end.uniq
+
+  directories.each do |dir|
+    Chef::Log.debug "Processing directory: #{dir}"
+    directory "#{new_resource.name}/#{dir}" do
+      owner     new_resource.owner
+      group     new_resource.group
+      mode      S3Lib::Dir.dir_mode new_resource.mode
+      action    :create
+      recursive true
+    end
+  end
+
+  remote_dir_contents.reject { |f| f[-1] == '/' }.each do |filename|
+    Chef::Log.debug "Processing file: #{filename}"
+    s3_file "#{new_resource.name}/#{filename}" do
+      remote_path "#{new_resource.dir}/#{filename}"
+      bucket new_resource.bucket
+      aws_access_key_id new_resource.access_key_id
+      aws_secret_access_key new_resource.secret_access_key
+      owner new_resource.owner
+      group new_resource.group
+      mode new_resource.mode
+      s3_url "#{s3_dir_lib.s3_url}/#{new_resource.bucket}"
+      action :create
     end
   end
 end

--- a/test/cookbooks/s3_dir_test/files/default/runmoto
+++ b/test/cookbooks/s3_dir_test/files/default/runmoto
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-start-stop-daemon --start --background --make-pidfile \
-  --pidfile /var/run/moto_server --exec /usr/local/bin/moto_server -- \
-    -H 127.0.0.1 s3

--- a/test/cookbooks/s3_dir_test/metadata.rb
+++ b/test/cookbooks/s3_dir_test/metadata.rb
@@ -6,5 +6,4 @@ description      'Installs/Configures s3_dir test cookbook'
 long_description 'Installs/Configures s3_dir test cookbook'
 version          '1.0.1'
 
-depends 'python'
 depends 's3_dir'

--- a/test/cookbooks/s3_dir_test/recipes/default.rb
+++ b/test/cookbooks/s3_dir_test/recipes/default.rb
@@ -1,37 +1,9 @@
 include_recipe 's3_dir::default'
 
-package 'python-pip'
-
-python_pip 'moto'
-
-cookbook_file '/usr/local/bin/runmoto' do
-  source 'runmoto'
-  owner  'root'
-  group  'root'
-  mode   0755
-end
-
-execute 'runmoto' do
-  command '/usr/local/bin/runmoto'
-  creates '/var/run/moto_server'
-  action  :run
-end
-
-s3_dir '/tmp/provisioning' do
-  bucket 'test-directory'
+s3_dir '/tmp/s3_dir_test' do
+  bucket 's3dir-test-bucket'
   dir '/s3_dir_test'
-  access_key_id 'TEST_KEY'
-  secret_access_key 'TEST_SECRET'
-  mock true
-  action :create
-end
-
-s3_dir '/tmp/provisioning-us-west-1' do
-  bucket 'test-directory-us-west-1'
-  dir '/s3_dir_test'
-  access_key_id 'TEST_KEY'
-  secret_access_key 'TEST_SECRET'
-  region 'us-west-1'
-  mock true
+  access_key_id node['s3_dir']['aws_access_key_id']
+  secret_access_key node['s3_dir']['aws_secret_access_key']
   action :create
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,23 +1,12 @@
 require 'spec_helper'
 
 describe 'S3 Dir test' do
-  describe file '/tmp/provisioning' do
+  describe file '/tmp/s3_dir_test/subdir/d1/d2/d3/d4' do
     it { should be_directory }
     it { should be_mode 775 }
   end
 
-  describe file '/tmp/provisioning/testdir' do
-    it { should be_directory }
-    it { should be_mode 775 }
-  end
-
-  describe file '/tmp/provisioning-us-west-1' do
-    it { should be_directory }
-    it { should be_mode 775 }
-  end
-
-  describe file '/tmp/provisioning-us-west-1/testdir' do
-    it { should be_directory }
-    it { should be_mode 775 }
+  describe file '/tmp/s3_dir_test/subdir/d1/d2/d3/d4/file' do
+    it { should be_file }
   end
 end


### PR DESCRIPTION
In S3 it's possible to have a file key with no associated directory key, e.g.

The fact that this key exists:
```
path/to/file
```
does not imply that this key exists:
```
path/to
```
Many clients will automatically create a `path/to` key when uploading a file (and, indeed Cyberduck blows up if that key doesn't exist), but not all do, so we should handle that case.

This relates to the suggested PR #3 but is a little more complicated so as to avoid unnecessarily cloning resources.