### PR TITLE
Add ability to read IAM role from server if running in aws.

### DIFF
--- a/libraries/s3_dir.rb
+++ b/libraries/s3_dir.rb
@@ -18,7 +18,7 @@ module S3Lib
       "https://s3-#{@region}.amazonaws.com"
     end
 
-    def initialize(access_key_id=nil, secret_access_key=nil, region=nil, is_mock=nil)
+    def initialize(access_key_id = nil, secret_access_key = nil, region = nil, is_mock = nil)
       require 'uri'
 
       @access_key_id = access_key_id
@@ -62,16 +62,16 @@ module S3Lib
 
         Fog.mock! if @is_mock
 
-        options = {region: @region,
-                   path_style: true
+        options = { region: @region,
+                    path_style: true
                   }
 
         if @access_key_id.nil?
-          options = options.merge({use_iam_profile: true})
+          options = options.merge(use_iam_profile: true)
         else
-          options = options.merge({ aws_access_key_id: @access_key_id,
-                                    aws_secret_access_key: @secret_access_key
-                                  })
+          options = options.merge(aws_access_key_id: @access_key_id,
+                                  aws_secret_access_key: @secret_access_key
+                                 )
         end
 
         [
@@ -79,7 +79,7 @@ module S3Lib
           :port,
           :scheme
         ].map { |key| options[key] = URI(s3_url).send(key) } if @is_mock
-        
+
         Fog::Storage::AWS.new(options)
       end
     end

--- a/libraries/s3_dir.rb
+++ b/libraries/s3_dir.rb
@@ -9,10 +9,6 @@ module S3Lib
       else
         mode = mode.to_s(8)
       end
-
-      (-3..-1).each do |i|
-        mode[i] = (mode[i].to_i + 1).to_s if !mode[i].to_i.zero? && mode.to_i.even?
-      end
       mode
     end
 
@@ -22,7 +18,7 @@ module S3Lib
       "https://s3-#{@region}.amazonaws.com"
     end
 
-    def initialize(access_key_id, secret_access_key, region, is_mock)
+    def initialize(access_key_id=nil, secret_access_key=nil, region=nil, is_mock=nil)
       require 'uri'
 
       @access_key_id = access_key_id
@@ -66,17 +62,24 @@ module S3Lib
 
         Fog.mock! if @is_mock
 
-        options = { aws_access_key_id: @access_key_id,
-                    aws_secret_access_key: @secret_access_key,
-                    region: @region,
-                    path_style: true }
+        options = {region: @region,
+                   path_style: true
+                  }
+
+        if @access_key_id.nil?
+          options = options.merge({use_iam_profile: true})
+        else
+          options = options.merge({ aws_access_key_id: @access_key_id,
+                                    aws_secret_access_key: @secret_access_key
+                                  })
+        end
 
         [
           :host,
           :port,
           :scheme
         ].map { |key| options[key] = URI(s3_url).send(key) } if @is_mock
-
+        
         Fog::Storage::AWS.new(options)
       end
     end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,7 +32,7 @@ action :create do
   directories = remote_dir_contents.map do |f|
     f[-1] == '/' ? f.sub(%r{/$}, '') : ::File.dirname(f)
   end.uniq
-
+  
   directories.each do |dir|
     Chef::Log.debug "Processing directory: #{dir}"
     directory "#{new_resource.name}/#{dir}" do
@@ -49,8 +49,8 @@ action :create do
     s3_file "#{new_resource.name}/#{filename}" do
       remote_path "#{new_resource.dir}/#{filename}"
       bucket new_resource.bucket
-      aws_access_key_id new_resource.access_key_id
-      aws_secret_access_key new_resource.secret_access_key
+      aws_access_key_id new_resource.access_key_id unless new_resource.access_key_id.nil?
+      aws_secret_access_key new_resource.secret_access_key unless new_resource.secret_access_key.nil?
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,7 +32,7 @@ action :create do
   directories = remote_dir_contents.map do |f|
     f[-1] == '/' ? f.sub(%r{/$}, '') : ::File.dirname(f)
   end.uniq
-  
+
   directories.each do |dir|
     Chef::Log.debug "Processing directory: #{dir}"
     directory "#{new_resource.name}/#{dir}" do
@@ -49,8 +49,10 @@ action :create do
     s3_file "#{new_resource.name}/#{filename}" do
       remote_path "#{new_resource.dir}/#{filename}"
       bucket new_resource.bucket
-      aws_access_key_id new_resource.access_key_id unless new_resource.access_key_id.nil?
-      aws_secret_access_key new_resource.secret_access_key unless new_resource.secret_access_key.nil?
+      aws_access_key_id new_resource.access_key_id unless
+        new_resource.access_key_id.nil?
+      aws_secret_access_key new_resource.secret_access_key unless
+        new_resource.secret_access_key.nil?
       owner new_resource.owner
       group new_resource.group
       mode new_resource.mode

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -7,8 +7,8 @@ attribute :mode,              kind_of: [String, Integer],           default: '07
 attribute :bucket,            kind_of: String
 attribute :dir,               kind_of: String,                      default: '/'
 attribute :recursive,         kind_of: [TrueClass, FalseClass],     default: false
-attribute :access_key_id,     kind_of: String
-attribute :secret_access_key, kind_of: String
+attribute :access_key_id,     kind_of: [String, NilClass],          default: nil
+attribute :secret_access_key, kind_of: [String, NilClass],          default: nil
 attribute :mock,              kind_of: [TrueClass, FalseClass],     default: false
 attribute :region,            kind_of: String,                      default: 'us-east-1'
 


### PR DESCRIPTION
 Also remove change of file mode on files.
1. Ideally we should be able to omit the acces key and secret key from the call to `s3_dir` and it should fall back on the role that the host uses. This is much more secure and follows best practices in aws. This is fairly easy to do but required some default parameters on the S3Lib `initialize` call. Due to those being first the the method signature I had to change the region and `is_mock` to defaults as well. I thought this is preferable to changing the order. Open to suggestions.
2. There was some strange functionality around adding the execute bit to the file mode. I’m guessing this is to allow recursive copying in the case of nested directories. However it had two flaws
   1. It was adding executable bits to every file not just to directories.
   2. there was a call to `mode.to_i.even?` that was taking into account the entire mode rather than just the number it was talking about. In the case of an `0700` mode it would mean that it would be bumped up to `0800` and be an invalid file mode.

Given both of these problems I took the loop out, But I’m also happy to find ways to add this back in.
